### PR TITLE
BIGTOP-3013: kafka charm: remove bigtop_version override

### DIFF
--- a/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
+++ b/bigtop-packages/src/charm/kafka/layer-kafka/config.yaml
@@ -1,11 +1,4 @@
 options:
-  bigtop_version:
-    type: string
-    default: 'master'
-    description: |
-        Apache Bigtop release version. The default, 'master' will use the
-        upsteam bits for all hiera data, puppet recipes, and installable
-        packages.
   network_interface:
     default: ""
     type: string


### PR DESCRIPTION
Fixes #347